### PR TITLE
fix(cb2-8524): searching for tech record is case sensitive

### DIFF
--- a/src/handler/search.ts
+++ b/src/handler/search.ts
@@ -15,7 +15,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   }
 
   const searchCriteria: SearchCriteria = event.queryStringParameters?.searchCriteria as SearchCriteria ?? SearchCriteria.ALL;
-  const searchIdentifier: string = decodeURIComponent(event.pathParameters?.searchIdentifier as string);
+  const searchIdentifier: string = decodeURIComponent(event.pathParameters?.searchIdentifier as string).toUpperCase();
   logger.info(`Search database with identifier ${searchIdentifier} and criteria ${searchCriteria}`);
 
   const searchResult = searchCriteria === SearchCriteria.ALL

--- a/tests/unit/handler/search.test.ts
+++ b/tests/unit/handler/search.test.ts
@@ -50,5 +50,15 @@ describe('Test Search Lambda Function', () => {
       expect(mockSearchByAll).toHaveBeenCalledTimes(1);
       expect(result).toEqual({ statusCode: 200, body: '["record 1","record 2"]', headers });
     });
+
+    it('should capitalise the searchIdentifier', async () => {
+      const searchIdentifier = 'a lower case string';
+      mockValidateSearchErrors.mockReturnValueOnce(null);
+      mockSearchByAll.mockResolvedValueOnce(['record 1', 'record 2']);
+      const result = await handler({ pathParameters: { searchIdentifier } } as unknown as APIGatewayProxyEvent);
+      expect(mockSearchByAll).toHaveBeenCalledTimes(1);
+      expect(mockSearchByAll).toHaveBeenLastCalledWith(searchIdentifier.toUpperCase());
+      expect(result).toEqual({ statusCode: 200, body: '["record 1","record 2"]', headers });
+    });
   });
 });


### PR DESCRIPTION
## Description

Searching for technical records is case sensitive, when it shouldn't be. All the search identifiers are upper cased when stored. 
Emulates the current/previous search behaviour [in `cvs-svc-technical-records`](https://github.com/dvsa/cvs-svc-technical-records/blob/b02be0859e3933c1080dfa7d674c78d3bf9d5028/src/models/TechRecordsDAO.ts#L70).

Related issue: [CB2-8524](https://dvsa.atlassian.net/browse/CB2-8524)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works