### PR TITLE
fix(cb2-8087): change update to validate against get schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@aws-sdk/smithy-client": "^3.341.0",
         "@aws-sdk/types": "^3.341.0",
-        "@dvsa/cvs-type-definitions": "^2.0.25",
+        "@dvsa/cvs-type-definitions": "^2.0.26",
         "@dvsa/eslint-config-ts": "^3.0.0",
         "@types/aws-lambda": "^8.10.114",
         "@types/jest": "^28.1.8",
@@ -1379,9 +1379,9 @@
       }
     },
     "node_modules/@dvsa/cvs-type-definitions": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-2.0.25.tgz",
-      "integrity": "sha512-kApYuJGg+SS2A9QTWjbwxcJ9NtCI6sovy5HjxzCQPQqGJ0KfqsioHX6MKlXfxw5Kv3hCNCYvVsO4ARx6I1GWPA==",
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-2.0.26.tgz",
+      "integrity": "sha512-8ppR/wit5ZIdfIVEmTcFz3pEq0Q+UkXUA1aPgUCsvvINH1i1OyiZAsKDego2u0KEL/T8R3E9R9Z/oTMg2Ar53w==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@aws-sdk/smithy-client": "^3.341.0",
     "@aws-sdk/types": "^3.341.0",
-    "@dvsa/cvs-type-definitions": "^2.0.25",
+    "@dvsa/cvs-type-definitions": "^2.0.26",
     "@dvsa/eslint-config-ts": "^3.0.0",
     "@types/aws-lambda": "^8.10.114",
     "@types/jest": "^28.1.8",

--- a/src/handler/update.ts
+++ b/src/handler/update.ts
@@ -58,7 +58,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
     const [updatedRecordFromDB, updatedNewRecord] = await processUpdateRequest(recordFromDB, requestBody, userDetails);
 
-    const record = await updateVehicle(updatedRecordFromDB as TechrecordGet, updatedNewRecord);
+    const record = await updateVehicle(updatedRecordFromDB as TechrecordGet, updatedNewRecord as TechrecordGet);
 
     const formattedRecord = formatTechRecord(record);
 

--- a/src/processors/processPostRequest.ts
+++ b/src/processors/processPostRequest.ts
@@ -3,7 +3,7 @@ import {
 } from '../models/post';
 import { generateNewNumber, NumberTypes } from '../services/testNumber';
 import { UserDetails } from '../services/user';
-import { ERRORS } from '../util/enum';
+import { ERRORS, HttpMethod } from '../util/enum';
 import { flattenArrays } from '../util/formatTechRecord';
 import logger from '../util/logger';
 import { isObjectEmpty } from '../validators/emptyObject';
@@ -15,7 +15,7 @@ export const processPostRequest = async (input: TechrecordPut, userDetails: User
     throw new Error(ERRORS.MISSING_PAYLOAD);
   }
 
-  (input as TechrecordGet).techRecord_recordCompleteness = validateAndComputeRecordCompleteness(input);
+  (input as TechrecordGet).techRecord_recordCompleteness = validateAndComputeRecordCompleteness(input, HttpMethod.PUT);
 
   const request: TechrecordPut = await flattenArrays(input) as TechrecordPut;
   // helper method for handler

--- a/src/processors/processUpdateRequest.ts
+++ b/src/processors/processUpdateRequest.ts
@@ -2,7 +2,7 @@ import {
   TechrecordCar, TechrecordGet, TechrecordHgv, TechrecordMotorcycle, TechrecordPsv, TechrecordPut, TechrecordTrl,
 } from '../models/post';
 import { UserDetails } from '../services/user';
-import { STATUS, UpdateType } from '../util/enum';
+import { HttpMethod, STATUS, UpdateType } from '../util/enum';
 import { flattenArrays, formatTechRecord } from '../util/formatTechRecord';
 import { validateAndComputeRecordCompleteness } from '../validators/recordCompleteness';
 
@@ -13,7 +13,7 @@ export const processUpdateRequest = async (recordFromDB: TechrecordGet, requestB
 
   const newRecord = { ...formattedRecordFromDB, ...updatedRequest } as TechrecordGet;
 
-  newRecord.techRecord_recordCompleteness = validateAndComputeRecordCompleteness(newRecord as TechrecordPut);
+  newRecord.techRecord_recordCompleteness = validateAndComputeRecordCompleteness(newRecord, HttpMethod.GET);
 
   const flattenedNewRecord = await flattenArrays(newRecord) as TechrecordGet;
 
@@ -43,7 +43,7 @@ export const setCreatedAuditDetails = (techRecord: TechrecordGet, createdByName:
   delete techRecord.techRecord_lastUpdatedAt;
   delete techRecord.techRecord_lastUpdatedById;
   delete techRecord.techRecord_lastUpdatedByName;
-  return techRecord as TechrecordPut;
+  return techRecord;
 };
 
 export const getUpdateType = (oldRecord: TechrecordGet, newRecord: TechrecordGet): UpdateType => {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -147,7 +147,7 @@ export const postTechRecord = async (request: TechrecordGet): Promise <Techrecor
   }
 };
 
-export const updateVehicle = async (oldRecord: TechrecordGet, newRecord: TechrecordPut): Promise<object> => {
+export const updateVehicle = async (oldRecord: TechrecordGet, newRecord: TechrecordGet): Promise<object> => {
   logger.info('inside updateVehicle');
 
   const transactWriteParams: TransactWriteCommandInput = {

--- a/src/util/enum.ts
+++ b/src/util/enum.ts
@@ -15,6 +15,7 @@ export enum RecordCompleteness {
 
 export enum HttpMethod {
   PUT = 'put',
+  GET = 'get',
 }
 
 export enum STATUS {

--- a/src/validators/recordCompleteness.ts
+++ b/src/validators/recordCompleteness.ts
@@ -1,43 +1,43 @@
 import { isValidObject } from '@dvsa/cvs-type-definitions/schema-validator';
-import { TechrecordPut } from '../models/post';
+import { TechrecordGet, TechrecordPut } from '../models/post';
 import { HttpMethod, RecordCompleteness, VehicleType } from '../util/enum';
 import logger from '../util/logger';
 import { identifySchema } from './post';
 
 /**
  * This function validates and changes the input in place and returns the RecordCompleteness.
- * @param input: TechrecordPut
+ * @param input: TechrecordPut | TechrecordGet
  * @returns RecordCompleteness
  *
  */
-export function validateAndComputeRecordCompleteness(input: TechrecordPut): RecordCompleteness {
+export function validateAndComputeRecordCompleteness(input: (TechrecordPut | TechrecordGet), method: HttpMethod): RecordCompleteness {
   if (input.techRecord_hiddenInVta) {
     logger.info('Hidden in VTA, returning skeleton');
-    validateSkeletonSchema(input);
+    validateSkeletonSchema(input, method);
     return RecordCompleteness.SKELETON;
   }
-  if (validateCompleteSchema(input)) {
+  if (validateCompleteSchema(input, method)) {
     return RecordCompleteness.COMPLETE;
   }
-  if (validateTestableSchema(input)) {
+  if (validateTestableSchema(input, method)) {
     return RecordCompleteness.TESTABLE;
   }
-  validateSkeletonSchema(input);
+  validateSkeletonSchema(input, method);
   return RecordCompleteness.SKELETON;
 }
 
-const validateSkeletonSchema = (input: TechrecordPut): boolean => {
-  const isSkeletonSchema = identifySchema(input.techRecord_vehicleType as VehicleType, RecordCompleteness.SKELETON, HttpMethod.PUT);
+const validateSkeletonSchema = (input: (TechrecordPut | TechrecordGet), method: HttpMethod): boolean => {
+  const isSkeletonSchema = identifySchema(input.techRecord_vehicleType as VehicleType, RecordCompleteness.SKELETON, method);
   return isSkeletonSchema ? isValidObject(isSkeletonSchema, input) : false;
 };
 
-const validateCompleteSchema = (input: TechrecordPut): boolean => {
-  const isCompleteSchema = identifySchema(input.techRecord_vehicleType as VehicleType, RecordCompleteness.COMPLETE, HttpMethod.PUT);
+const validateCompleteSchema = (input: (TechrecordPut | TechrecordGet), method: HttpMethod): boolean => {
+  const isCompleteSchema = identifySchema(input.techRecord_vehicleType as VehicleType, RecordCompleteness.COMPLETE, method);
   return isCompleteSchema ? (isValidObject(isCompleteSchema, input)) : false;
 };
 
-const validateTestableSchema = (input: TechrecordPut): boolean => {
+const validateTestableSchema = (input: (TechrecordPut | TechrecordGet), method: HttpMethod): boolean => {
   const isTestableSchema = input.techRecord_vehicleType === (VehicleType.TRL || VehicleType.PSV || VehicleType.HGV)
-    ? identifySchema(input.techRecord_vehicleType as VehicleType, RecordCompleteness.TESTABLE, HttpMethod.PUT) : '';
+    ? identifySchema(input.techRecord_vehicleType as VehicleType, RecordCompleteness.TESTABLE, method) : '';
   return isTestableSchema ? (isValidObject(isTestableSchema, input)) : false;
 };

--- a/tests/resources/techRecordCarPost.json
+++ b/tests/resources/techRecordCarPost.json
@@ -27,6 +27,7 @@
   "techRecord_vehicleConfiguration": "other",
   "techRecord_vehicleSize": null,
   "techRecord_vehicleType": "car",
+  "techRecord_vehicleSubclass": ["a"],
   "vin": "AA11100851",
   "vehicleSubclass": [
     "r"

--- a/tests/unit/processors/processUpdateRequest.test.ts
+++ b/tests/unit/processors/processUpdateRequest.test.ts
@@ -31,7 +31,7 @@ describe('getUpdateType', () => {
 describe('processUpdateRequest', () => {
   it('returns updated records to archive and to add', async () => {
     const mockRecordFromDb = hgvData as TechrecordGet;
-    const mockRequest = { techRecord_reasonForCreation: 'Test Update', techRecord_emissionsLimit: 3 } as TechrecordGet;
+    const mockRequest = { techRecord_reasonForCreation: 'Test Update', techRecord_emissionsLimit: 3 } as TechrecordPut;
     const mockUserDetails: UserDetails = {
       username: 'UpdateUser', msOid: 'QWERTY', email: 'UpdateUser@test.com',
     };

--- a/tests/unit/validators/recordCompleteness.test.ts
+++ b/tests/unit/validators/recordCompleteness.test.ts
@@ -2,17 +2,23 @@ import { validateAndComputeRecordCompleteness } from '../../../src/validators/re
 import hgvData from '../../resources/techRecordHGVPost.json';
 import * as expectedRecords from '../../resources/tech-records-with-arrays.json';
 import { TechrecordPut } from '../../../src/models/post';
-import { RecordCompleteness } from '../../../src/util/enum';
+import { HttpMethod, RecordCompleteness } from '../../../src/util/enum';
 
 describe('validateAndComputeRecordCompleteness', () => {
   it('should return correct record completeness', () => {
-    expect(validateAndComputeRecordCompleteness(expectedRecords[0] as unknown as TechrecordPut)).toEqual(RecordCompleteness.SKELETON);
-    expect(validateAndComputeRecordCompleteness(hgvData as TechrecordPut)).toEqual(RecordCompleteness.COMPLETE);
+    expect(validateAndComputeRecordCompleteness(expectedRecords[0] as unknown as TechrecordPut, HttpMethod.GET)).toEqual(RecordCompleteness.SKELETON);
+    expect(validateAndComputeRecordCompleteness(hgvData as TechrecordPut, HttpMethod.GET)).toEqual(RecordCompleteness.COMPLETE);
   });
   it('should remove any random fields from the input', () => {
     const mockHgvData = { ...hgvData, randomField: 'Test' };
-    expect(validateAndComputeRecordCompleteness(mockHgvData as TechrecordPut)).toEqual(RecordCompleteness.COMPLETE);
+    expect(validateAndComputeRecordCompleteness(mockHgvData as TechrecordPut, HttpMethod.GET)).toEqual(RecordCompleteness.COMPLETE);
     expect(mockHgvData).toEqual(hgvData);
+    expect(mockHgvData).not.toHaveProperty('randomField');
+  });
+  it('should remove GET related fields from the input if using PUT method', () => {
+    const mockHgvData = { ...hgvData, randomField: 'Test' };
+    expect(validateAndComputeRecordCompleteness(mockHgvData as TechrecordPut, HttpMethod.PUT)).toEqual(RecordCompleteness.COMPLETE);
+    expect(mockHgvData).not.toHaveProperty('createdTimestamp');
     expect(mockHgvData).not.toHaveProperty('randomField');
   });
 });


### PR DESCRIPTION
## change update to validate against GET schema

- changed the validate function to accept the HTTP method to select the correct schema for validation

Related issue: [cb2-8087](https://dvsa.atlassian.net/browse/CB2-8087)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works