### PR TITLE
fix(cb2-8089): return reason for creation from update vrm cherished transfer

### DIFF
--- a/src/processors/processVrmRequest.ts
+++ b/src/processors/processVrmRequest.ts
@@ -13,8 +13,8 @@ export const processPatchVrmRequest = (currentRecord: TechRecordGet, userDetails
     const updatedNewRecord = setCreatedAuditDetails(newRecord, userDetails.username, userDetails.msOid, new Date().toISOString(), currentRecord.techRecord_statusCode as StatusCode);
     (updatedNewRecord as TechRecordHgv | TechRecordMotorcycle | TechRecordCar | TechRecordPsv).primaryVrm = newVrm.toUpperCase();
     const updatedRecordToArchive = setLastUpdatedAuditDetails(recordToArchive, userDetails.username, userDetails.msOid, new Date().toISOString(), StatusCode.ARCHIVED);
-
-    return [updatedRecordToArchive, newRecord];
+    updatedNewRecord.techRecord_reasonForCreation = 'Update VRM - Cherished Transfer';
+    return [updatedRecordToArchive, updatedNewRecord];
   }
   const newRecord: TechRecordGet = { ...currentRecord };
   const updatedRecordToArchive = {} as TechRecordGet;

--- a/tests/unit/processors/processVrmRequest.test.ts
+++ b/tests/unit/processors/processVrmRequest.test.ts
@@ -25,6 +25,7 @@ describe('processVrmRequest', () => {
         createdTimestamp: mockedDate.toISOString(),
         techRecord_createdByName: 'Test User',
         techRecord_createdById: 'QWERTY',
+        techRecord_reasonForCreation: 'Update VRM - Cherished Transfer',
       }));
       expect(recordToArchive).toEqual(expect.objectContaining({
         primaryVrm: '991234Z',


### PR DESCRIPTION
## Update VTM front end to utilise v3 Tech Records API for light vehicles 

return reason for creation from update vrm cherished transfer
Related issue: [CB2-8089](https://dvsa.atlassian.net/browse/CB2-8089)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works