### PR TITLE
CB2-8858: Add non key attributes to DynamoDB table

### DIFF
--- a/scripts/setup-local-tables.ts
+++ b/scripts/setup-local-tables.ts
@@ -24,6 +24,8 @@ const flatTechRecordNonKeyAttributes: SearchResultKeys[] = [
   'techRecord_make',
   'techRecord_model',
   'techRecord_statusCode',
+  'techRecord_reasonForCreation',
+  'techRecord_createdByName',
 ];
 
 const tablesToSetup: CreateTableInput[] = [

--- a/src/models/search.ts
+++ b/src/models/search.ts
@@ -22,5 +22,5 @@ export interface SearchResult {
   techRecord_model?: string
   techRecord_statusCode?: string
   techRecord_reasonForCreation?: string
-  techRecord_createdByName?: string;
+  techRecord_createdByName?: string
 }

--- a/src/models/search.ts
+++ b/src/models/search.ts
@@ -22,5 +22,5 @@ export interface SearchResult {
   techRecord_model?: string
   techRecord_statusCode?: string
   techRecord_reasonForCreation?: string
-  techRecord_lastUpdatedByName?: string
+  techRecord_createdByName?: string;
 }


### PR DESCRIPTION
## Add non key attributes to dynamoDB table

This change is to include additional not key attributes to the local DynamoDB and added the keys to the search model

Related issue: [JIRA_TICKET_NUMBER](https://dvsa.atlassian.net/browse/CB2-8858)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works