### PR TITLE
fix(cb2-9269):  IVA test types missing for LGV and PSV Provisional Tech Records

### DIFF
--- a/src/validators/statusUpdate.ts
+++ b/src/validators/statusUpdate.ts
@@ -7,11 +7,12 @@ export const validateUpdateStatus = (
       && (testResult === 'pass' || testResult === 'prs')
       && (isTestTypeFirstTest(testTypeId)
         || isTestTypeNotifiableAlteration(testTypeId)
-        || isTestTypeCOIF(testTypeId))
+        || isTestTypeCOIF(testTypeId)
+        || isTestTypeIVA(testTypeId))
 );
 
 function isTestTypeFirstTest(testTypeId: string): boolean {
-  const firstTestIds = ['41', '95', '65', '66', '67', '103', '104', '82', '83', '119', '120', '186', '188', '192', '194'];
+  const firstTestIds = ['41', '95', '65', '66', '67', '103', '104', '82', '83', '119', '120'];
   return firstTestIds.includes(testTypeId);
 }
 
@@ -23,4 +24,11 @@ function isTestTypeNotifiableAlteration(testTypeId: string): boolean {
 function isTestTypeCOIF(testTypeId: string): boolean {
   const coifIds = ['142', '143', '175', '176'];
   return coifIds.includes(testTypeId);
+}
+
+function isTestTypeIVA(testTypeId: string): boolean {
+  const ivaIds = ['133', '134', '138', '139', '140', '165', '169', '167', '170', '135', '172', '173', '439', '449',
+    '136', '187', '126', '186', '193', '192', '195', '162', '191', '128', '188', '189', '125', '161', '158', '159',
+    '154', '190', '129', '196', '194', '197', '185', '420', '438', '163', '153', '184', '130', '183'];
+  return ivaIds.includes(testTypeId);
 }


### PR DESCRIPTION
CB2-9269

auto promote IVA tests 

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works