### PR TITLE
patch(cb2-9602): Update types package and HGV post ref data

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@aws-sdk/client-sqs": "^3.382.0",
     "@aws-sdk/lib-dynamodb": "^3.341.0",
     "@aws-sdk/util-dynamodb": "^3.362.0",
-    "@dvsa/cvs-type-definitions": "^3.6.0",
+    "@dvsa/cvs-type-definitions": "^3.6.1",
     "@types/luxon": "^3.3.0",
     "jwt-decode": "^3.1.2",
     "luxon": "^3.3.0",

--- a/tests/resources/techRecordHGVPost.json
+++ b/tests/resources/techRecordHGVPost.json
@@ -26,7 +26,7 @@
     "techRecord_dimensions_length": 10000,
     "techRecord_dimensions_width": 2500,
     "techRecord_drawbarCouplingFitted": false,
-    "techRecord_emissionsLimit": 6,
+    "techRecord_emissionsLimit": 6.2,
     "techRecord_euVehicleCategory": "n3",
     "techRecord_euroStandard": "Euro 6",
     "techRecord_frontAxleTo5thWheelMax": 0,


### PR DESCRIPTION
## Description

Introduces a float value to the HGV reference data and updates the type package to include the emissionLimit changes.

Related issue: [CB2-9602](https://dvsa.atlassian.net/browse/CB2-9602)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works