### PR TITLE
fix(cb2-10791): Remediate the ~1300 TRL Tech Records with a Primary VRM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@aws-sdk/util-dynamodb": "^3.362.0",
         "@dvsa/cvs-type-definitions": "^5.1.2",
         "@types/luxon": "^3.3.0",
+        "async-sema": "^3.1.1",
         "jwt-decode": "^3.1.2",
         "luxon": "^3.3.0",
         "polly-js": "^1.8.3"
@@ -4560,6 +4561,11 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
       "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
       "dev": true
+    },
+    "node_modules/async-sema": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
+      "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg=="
     },
     "node_modules/asynciterator.prototype": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test-i": "echo 'nothing to do'",
     "test:integration:github": "jest int --globalSetup='./scripts/spin-up-lambdas.ts' --globalTeardown='./scripts/destroy-lambdas.ts' --testTimeout 20000",
     "test:integration": "jest int --testTimeout 20000",
+    "test:hotfix": "jest --testTimeout 20000 hotfix",
     "package": "npm run build:prod",
     "start:ci": "npm run dynamo:seed && sam local start-api --docker-network $(docker network ls | grep github_network | awk '{print $2}') --warm-containers EAGER",
     "swagger:open": "docker run --name swagger -d -p 80:8080 -v $(pwd)/docs:/tmp -e SWAGGER_FILE=/tmp/spec.yml swaggerapi/swagger-editor"
@@ -44,6 +45,7 @@
     "@aws-sdk/util-dynamodb": "^3.362.0",
     "@dvsa/cvs-type-definitions": "^5.1.2",
     "@types/luxon": "^3.3.0",
+    "async-sema": "^3.1.1",
     "jwt-decode": "^3.1.2",
     "luxon": "^3.3.0",
     "polly-js": "^1.8.3"

--- a/src/hotfix/removeInvalidPrimaryVrms.ts
+++ b/src/hotfix/removeInvalidPrimaryVrms.ts
@@ -1,0 +1,121 @@
+import { APIGatewayProxyResult } from 'aws-lambda';
+import 'dotenv/config';
+
+import { RateLimit } from 'async-sema';
+import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
+
+import { setCreatedAuditDetails, setLastUpdatedAuditDetails } from '../services/audit';
+import invalidPrimaryVrmRecords from './resources/invalid-primary-vrms.json';
+import {
+  getBySystemNumberAndCreatedTimestamp,
+  updateVehicle,
+} from '../services/database';
+import { ERRORS, StatusCode } from '../util/enum';
+import { addHttpHeaders } from '../util/httpHeaders';
+import { formatErrorMessage } from '../util/errorMessage';
+import logger from '../util/logger';
+
+export const handler = async (forceUpdateTimestamp?: Date): Promise<APIGatewayProxyResult> => {
+  try {
+    logger.debug('RPVRM: Remove Primary VRM for Trailers Called');
+
+    const recordsToUpdate = invalidPrimaryVrmRecords.length;
+    let numberOfRecordUpdated = 0;
+
+    logger.debug(`RPVRM: ${recordsToUpdate} tech records to update`);
+
+    const limit = RateLimit(25);
+    // const techRecordChunks = chunk(invalidPrimaryVrmRecords, 25);
+
+    for (const techRecord of invalidPrimaryVrmRecords) {
+      await limit();
+
+      const systemNumber = techRecord.system_number;
+      const createdTimestamp = new Date(techRecord.createdAt).toISOString();
+      const currentRecord = await getBySystemNumberAndCreatedTimestamp(
+        systemNumber,
+        createdTimestamp,
+      );
+
+      // Validate the state of the current (invalid) record.
+      if (!validatePrimaryVrmIsInvalid(currentRecord)) {
+        continue;
+      }
+
+      // Instantiate a new record from the current one and archive the existing record.
+      const date = forceUpdateTimestamp ?? new Date();
+      const [newRecord, recordToArchive] = archiveAndInstantiateNewTechRecord(currentRecord, date);
+
+      // Update sucka
+      const result = await updateVehicle([recordToArchive], [newRecord]) as TechRecordType<'get'>[];
+      numberOfRecordUpdated += result.length;
+    }
+
+    return addHttpHeaders({
+      statusCode: 200,
+      body: `RPVRM: Updated ${numberOfRecordUpdated} invalid tech records`,
+    });
+  }
+  catch {
+    return addHttpHeaders({
+      statusCode: 500,
+      body: formatErrorMessage(ERRORS.FAILED_UPDATE_MESSAGE),
+    });
+  }
+}
+
+// Ensures that a technical record meets the criteria to be in an invalid state
+// for the primary vrm data incident.
+// Ultimately this ensures the vehicle is a trailer and has a primary vrm set.
+const validatePrimaryVrmIsInvalid = (techRecord: TechRecordType<'get'>): boolean => {
+  if (techRecord.techRecord_vehicleType !== 'trl') {
+    logger.error(
+      `RPVRM: Invalid tech record: type is not 'trl' (${techRecord.systemNumber}, ${techRecord.createdTimestamp})`
+    );
+    return false;
+  }
+
+  if (!('primaryVrm' in techRecord)) {
+    logger.error(
+      `RPVRM: Invalid tech record: missing primaryVrm (${techRecord.systemNumber}, ${techRecord.createdTimestamp})`
+    );
+    return false;
+  }
+
+  return true;
+}
+
+// Takes a technical record, updates it to archived and create a new instance from the input parameter
+// with the primary vrm removed.
+// Updates are made by SYSTEM_USER
+const archiveAndInstantiateNewTechRecord = (currentRecord: TechRecordType<'get'>, updateDate: Date):
+    [TechRecordType<'get'>, TechRecordType<'get'>] => {
+  const SYSTEM_USER = 'SYSTEM USER';
+  const REASON_FOR_CREATION = 'Primary VRM removed for trailer (CB2-10791)';
+
+  const date = updateDate.toISOString();
+
+  const newRecord = {
+    ...currentRecord,
+    primaryVrm: undefined,
+    techRecord_reasonForCreation: REASON_FOR_CREATION
+  };
+
+  const recordToCreate = setCreatedAuditDetails(
+    newRecord as TechRecordType<'get'>,
+    SYSTEM_USER,
+    SYSTEM_USER,
+    date,
+    currentRecord.techRecord_statusCode as StatusCode,
+  );
+
+  const recordToArchive = setLastUpdatedAuditDetails(
+    currentRecord,
+    SYSTEM_USER,
+    SYSTEM_USER,
+    date,
+    StatusCode.ARCHIVED,
+  );
+
+  return [recordToCreate, recordToArchive];
+}

--- a/src/hotfix/tests/integration/removeInvalidPrimaryVrms.int.test.ts
+++ b/src/hotfix/tests/integration/removeInvalidPrimaryVrms.int.test.ts
@@ -1,0 +1,122 @@
+import { seedTables } from '../../../../scripts/setup-local-tables';
+import { tableName } from '../../../config';
+import { handler as removePrimaryVrm } from '../../removeInvalidPrimaryVrms';
+import techRecordData from './resources/technical-records-v3-invalid-primaryvrm.json';
+import invalidVrms from '../../resources/invalid-primary-vrms.json';
+import * as fs from 'fs';
+
+describe('remove primary vrms function', () => {
+  beforeEach(async () => {
+    await seedTables([{
+      table: tableName,
+      data: techRecordData,
+    }]);
+  });
+
+  describe('update data', () => {
+    const output = [];
+    for (let i = 0; i < invalidVrms.length; i++) {
+      const invalidVrm = invalidVrms[i];
+
+      const techRecord = {
+        ...techRecordData[i],
+        createdTimestamp: new Date(invalidVrm.createdAt).toISOString(),
+        primaryVrm: invalidVrm.trailer_id,
+        systemNumber: invalidVrm.system_number,
+        vin: invalidVrm.vin
+      };
+
+      output.push(techRecord);
+    }
+
+    fs.writeFileSync(`./output.json`, JSON.stringify(output));
+  });
+
+  describe('happy path', () => {
+    it('should remove the primary vrm', async () => {
+      return true;
+      process.env.AWS_SAM_LOCAL = 'true';
+
+      // Arrange
+
+      // (would be better to DI a DateProvider, generally speaking, but this will do for now)
+      const forceUpdateTimestamp = new Date();
+
+      // Act
+      const result = await removePrimaryVrm(forceUpdateTimestamp);
+
+      // Assert
+      expect(result.statusCode).toEqual(200);
+
+      // Only n records should have been updated
+      expect(result.body).toEqual(`RPVRM: Updated ${invalidVrms.length} invalid tech records`);
+
+      // Sanity check, ensure the primary vrm was falsified.
+      for (const tr of invalidVrms) {
+        const systemNumber = tr.system_number;
+        const date = forceUpdateTimestamp.toISOString();
+
+        const response = await fetch(`http://127.0.0.1:3000/v3/technical-records/${systemNumber}/${date}`);
+        expect(response.status).toBe(200);
+
+        const updatedTechRecord = await response.json();
+        expect('primaryVrm' in updatedTechRecord).toBeFalsy();
+      }
+
+      // const updatedResponse = await fetch(
+      //   `http://127.0.0.1:3000/v3/technical-records/${systemNumber}/${forceUpdateTimestamp.toISOString()}`
+      // );
+
+      // expect(updatedResponse.status).toBe(200);
+
+      // const updatedTechRecord = await updatedResponse.json();
+
+      // expect('primaryVrm' in updatedTechRecord).toBeFalsy();
+    });
+  });
+
+  // describe('unhappy path', () => {
+  //   it('should return an error message if vehicle type is missing', async () => {
+  //     const response = await fetch(
+  //       'http:/127.0.0.1:3000/v3/technical-records',
+  //       {
+  //         method: 'POST',
+  //         body: JSON.stringify({}),
+  //         headers: {
+  //           Authorization: mockToken,
+  //         },
+  //       },
+  //     );
+
+  //     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  //     const json = await response.json();
+
+  //     expect(json).toEqual({ errors: [ERRORS.VEHICLE_TYPE_ERROR] });
+  //     expect(response.status).toBe(400);
+  //   });
+
+  //   it('should return the required fields to create if the body does not have them', async () => {
+  //     const body = { techRecord_vehicleType: 'psv' };
+  //     const response = await fetch(
+  //       'http:/127.0.0.1:3000/v3/technical-records',
+  //       {
+  //         method: 'POST',
+  //         body: JSON.stringify(body),
+  //         headers: {
+  //           Authorization: mockToken,
+  //         },
+  //       },
+  //     );
+
+  //     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  //     const json = await response.json();
+
+  //     const requiredFields = psvSchema.required
+  //       .filter((field) => !Object.keys(body).includes(field))
+  //       .map((field: string) => `must have required property '${field}'`);
+
+  //     expect(json).toEqual({ errors: requiredFields });
+  //     expect(response.status).toBe(400);
+  //   });
+  // });
+});

--- a/template.yml
+++ b/template.yml
@@ -167,5 +167,14 @@ Resources:
             Properties:
               Path: !GetAtt LocalQueue.Arn
               BatchSize: 10
+
+    RemoveInvalidPrimaryVrms:
+      Type: 'AWS::Serverless::Function'
+      Properties:
+        CodeUri: src/hotfix/
+        Handler: removeInvalidPrimaryVrms.handler
+        Runtime: nodejs18.x
+        Timeout: 20
+
     LocalQueue:
       Type: AWS::SQS::Queue

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "strict": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts", "scripts/**/*.ts"]
+  "include": ["src/**/*.ts", "hotfix/**/*.ts", "tests/**/*.ts", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
## Description

Creates a hotfix to run in aws console to fix the ~1300 invalid TRL tech records that have a primary vrm assigned.

Related issue: [CB2-10791](https://dvsa.atlassian.net/browse/CB2-10791)

**Outstanding items**

*Test data*
Test data has not been included as this contains PII. Considerations need to be made about how we scaffold and run these tests as part of the deployment pipeline. This will likely involve uploading the affected trailers and test data to an S3 and arranging the tests from those data sets.

*Batching the updates*
At the moment a semaphore is rate limiting the updates, we also want to batch the updates so we can issue ~25 at a time.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works