### PR TITLE
feat(cb2-10672): adr certificate generation is available when a pass result is selected for adr contingency tests

### DIFF
--- a/src/handler/adrCertificate.ts
+++ b/src/handler/adrCertificate.ts
@@ -105,7 +105,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
     return addHttpHeaders({
       statusCode: 200,
-      body: JSON.stringify('ADR certificate generation successful'),
+      body: JSON.stringify({ message: 'ADR certificate generation successful', id: newAdrCertificate.certificateId }),
     });
   } catch (e) {
     logger.error(`Error has been thrown with ${JSON.stringify(e)}`);

--- a/tests/unit/handler/adrCertificate.unit.test.ts
+++ b/tests/unit/handler/adrCertificate.unit.test.ts
@@ -184,11 +184,7 @@ describe('Test adr cert gen lambda', () => {
         body: JSON.stringify(payload),
       } as unknown as APIGatewayProxyEvent);
       expect(mockAddToSqs).toHaveBeenCalledWith(expectedSqsPayload, expect.anything());
-      expect(res).toEqual({
-        statusCode: 200,
-        body: JSON.stringify('ADR certificate generation successful'),
-        headers,
-      });
+      expect(JSON.parse(res.body)).toEqual(expect.objectContaining({ message: 'ADR certificate generation successful' }));
     });
   });
 });


### PR DESCRIPTION
## Description

sends back the ID for the certificate to enable the use of the link in the contingency test flow

Include a summary of the change here.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works