### PR TITLE
feat(cb2-10795): pass user email address via sqs so PDF can be emailed

### DIFF
--- a/src/handler/adrCertificate.ts
+++ b/src/handler/adrCertificate.ts
@@ -96,7 +96,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       techRecord: arrayifiedRecord,
       adrCertificate: newAdrCertificate,
       documentName: DocumentName.ADR_PASS_CERTIFICATE,
-      recipientEmailAddress: '',
+      recipientEmailAddress: userDetails.email,
     };
 
     logger.debug(JSON.stringify(adrCertSqsPayload));

--- a/tests/unit/handler/adrCertificate.unit.test.ts
+++ b/tests/unit/handler/adrCertificate.unit.test.ts
@@ -176,7 +176,7 @@ describe('Test adr cert gen lambda', () => {
         techRecord: { ...formattedRecord as HgvOrTrl, techRecord_adrPassCertificateDetails: [adrCertificate] },
         adrCertificate,
         documentName: DocumentName.ADR_PASS_CERTIFICATE,
-        recipientEmailAddress: '',
+        recipientEmailAddress: undefined,
       };
 
       const res = await handler({


### PR DESCRIPTION
## Email generated ADR certificate PDF to logged in user

Passes user email address via SQS payload so the generated ADR certificate PDF can be emailed to the user conducting the ADR test.

Related issue: [CB2-10795](https://dvsa.atlassian.net/browse/CB2-10795)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works