### PR TITLE
Archive technical records before creating new ones (part of Remediate the ~1300 TRL Tech Records with a Primary VRM)

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -157,15 +157,6 @@ export const updateVehicle = async (recordsToArchive: TechRecordType<'get'>[], n
 
   const transactWriteParams: TransactWriteCommandInput = { TransactItems: [] };
 
-  newRecords.forEach((record) => {
-    transactWriteParams.TransactItems?.push({
-      Put: {
-        TableName: tableName,
-        Item: marshall(record, { removeUndefinedValues: true }),
-      },
-    });
-  });
-
   recordsToArchive.forEach((record) => {
     transactWriteParams.TransactItems?.push(
       {
@@ -176,6 +167,15 @@ export const updateVehicle = async (recordsToArchive: TechRecordType<'get'>[], n
         },
       },
     );
+  });
+
+  newRecords.forEach((record) => {
+    transactWriteParams.TransactItems?.push({
+      Put: {
+        TableName: tableName,
+        Item: marshall(record, { removeUndefinedValues: true }),
+      },
+    });
   });
 
   const sendTransaction = new Promise<object>((resolve, reject) => {


### PR DESCRIPTION
## Description

This is an additional change for an observation made in the hotfix for the same JIRA ticket.

The ordering of the new/archive operations matters to downstream services.

Related issue: [CB2-10791](https://dvsa.atlassian.net/browse/CB2-10791)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works