### PR TITLE
feat(cb2-10905): Webpack Aws Sdk Update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,6 @@
       "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "3.359.0",
-        "@aws-sdk/client-lambda": "3.362.0",
-        "@aws-sdk/client-sns": "3.485.0",
-        "@aws-sdk/client-sqs": "3.382.0",
-        "@aws-sdk/lib-dynamodb": "^3.341.0",
-        "@aws-sdk/util-dynamodb": "^3.362.0",
         "@dvsa/cvs-type-definitions": "^5.1.2",
         "@types/luxon": "^3.3.0",
         "jwt-decode": "^3.1.2",
@@ -22,6 +16,12 @@
         "polly-js": "^1.8.3"
       },
       "devDependencies": {
+        "@aws-sdk/client-dynamodb": "3.359.0",
+        "@aws-sdk/client-lambda": "3.362.0",
+        "@aws-sdk/client-sns": "3.485.0",
+        "@aws-sdk/client-sqs": "3.382.0",
+        "@aws-sdk/lib-dynamodb": "^3.341.0",
+        "@aws-sdk/util-dynamodb": "^3.362.0",
         "@aws-sdk/smithy-client": "^3.341.0",
         "@aws-sdk/types": "^3.341.0",
         "@dvsa/eslint-config-ts": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,12 +38,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "3.359.0",
-    "@aws-sdk/client-lambda": "3.362.0",
-    "@aws-sdk/client-sns": "3.485.0",
-    "@aws-sdk/client-sqs": "3.382.0",
-    "@aws-sdk/lib-dynamodb": "^3.341.0",
-    "@aws-sdk/util-dynamodb": "^3.362.0",
     "@dvsa/cvs-type-definitions": "^5.1.2",
     "@types/luxon": "^3.3.0",
     "jwt-decode": "^3.1.2",
@@ -51,6 +45,12 @@
     "polly-js": "^1.8.3"
   },
   "devDependencies": {
+    "@aws-sdk/client-dynamodb": "3.359.0",
+    "@aws-sdk/client-lambda": "3.362.0",
+    "@aws-sdk/client-sns": "3.485.0",
+    "@aws-sdk/client-sqs": "3.382.0",
+    "@aws-sdk/lib-dynamodb": "^3.341.0",
+    "@aws-sdk/util-dynamodb": "^3.362.0",
     "@aws-sdk/smithy-client": "^3.341.0",
     "@aws-sdk/types": "^3.341.0",
     "@dvsa/eslint-config-ts": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
     "polly-js": "^1.8.3"
   },
   "devDependencies": {
-    "@aws-sdk/client-dynamodb": "3.359.0",
-    "@aws-sdk/client-lambda": "3.362.0",
-    "@aws-sdk/client-sns": "3.485.0",
-    "@aws-sdk/client-sqs": "3.382.0",
+    "@aws-sdk/client-dynamodb": "^3.359.0",
+    "@aws-sdk/client-lambda": "^3.362.0",
+    "@aws-sdk/client-sns": "^3.485.0",
+    "@aws-sdk/client-sqs": "^3.382.0",
     "@aws-sdk/lib-dynamodb": "^3.341.0",
     "@aws-sdk/util-dynamodb": "^3.362.0",
     "@aws-sdk/smithy-client": "^3.341.0",

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -23,13 +23,10 @@ module.exports = {
   // Target node
   target: 'node',
 
-  // AWS recommends always including the aws-sdk in your Lambda package but excluding can significantly reduce
-  // the size of your deployment package. If you want to always include it then comment out this line. It has
-  // been included conditionally because the node10.x docker image used by SAM local doesn't include it.
-  // externals: process.env.NODE_ENV === 'development' ? [] : ['aws-sdk'],
-  externals: {
-    fsevents: 'require(\'fsevents\')',
-  },
+  externals: [
+    /aws-sdk/,
+    'fsevents'
+  ],
 
   // Add the TypeScript loader
   module: {


### PR DESCRIPTION
## Description

Fixes an issue where Webpack was incorrectly chunking up the AWS SDK dependency upon packaging releases. This changes it to be a dev dependency as the AWS SDK is technically provided as part of all AWS Lambda runtime containers anyway.

Related issue: [CB2-10905](https://dvsa.atlassian.net/browse/CB2-10905)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works