### PR TITLE
feat(cb2-11450): allow system user to be forced for the user context

### DIFF
--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -12,7 +12,25 @@ export const getUserDetails = (jwt: string): UserDetails => {
     msOid: decodedToken.oid,
     email: decodedToken.email ?? decodedToken.preferred_username ?? decodedToken.upn,
   };
+
   if (!userDetails?.username || !userDetails.msOid) {
+    // Data remediation requirements...
+    // If we have an authenticated token, but it is not running in the context of a user
+    // then it will be a client_credentials grant_type e.g. the data remediation app.
+    // In this scenario, this is a valid path, but the request is not running in the context of a user,
+    // so we don't have a username or email available in the token.
+    // To accommodate this, we can set an environment variable that allows for the username and email
+    // to be set to SYSTEM_USER.
+
+    // TODO: Can we replace this with custom claims in the Entra app registration. This way we can define
+    //       'client' (data remediation app) contact details for use here.
+    // TODO: The token dependency here should be refactored into the authorizer context object.
+    if (process.env.ENABLE_SYSTEM_USER_IMPERSONATION ?? false) {
+      userDetails.username = 'SYSTEM_USER';
+      userDetails.email = 'SYSTEM_USER';
+      return userDetails;
+    }
+
     throw new Error(ERRORS.MISSING_USER_DETAILS);
   }
   return userDetails;


### PR DESCRIPTION
## Description

Data remediation updates tech records, but does not run in a user context - it's a client_credentials grant. Enable an env var to be set that allows the missing values to be set to SYSTEM_USER.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works