### PR TITLE
feat(cb2-11103): update types package for updated createdAtDate format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
-        "@dvsa/cvs-type-definitions": "^6.1.0",
+        "@dvsa/cvs-type-definitions": "^6.2.0",
         "@types/luxon": "^3.3.0",
         "jwt-decode": "^3.1.2",
         "luxon": "^3.3.0",
@@ -4385,9 +4385,9 @@
       }
     },
     "node_modules/@dvsa/cvs-type-definitions": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-6.1.0.tgz",
-      "integrity": "sha512-NPS0mvEfRAiwCuLNHdq5Ip+dmx9KJQKX0RkHV6g0lmsDFwPasL+91R716Mgo44O/shBkeT9XsIQq3ZSoA3iOFA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-6.2.0.tgz",
+      "integrity": "sha512-r1oPXfn0WeP9zitBJVU+w0r4Eco4t02Wl54UdxeEdJ6B0u0BNC7mIQ1Wr1RqQmMw4kCFSIYop6RinEVpbp/WtA==",
       "dependencies": {
         "ajv": "^8.12.0",
         "json-schema-deref-sync": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@dvsa/cvs-type-definitions": "^6.1.0",
+    "@dvsa/cvs-type-definitions": "^6.2.0",
     "@types/luxon": "^3.3.0",
     "jwt-decode": "^3.1.2",
     "luxon": "^3.3.0",


### PR DESCRIPTION
## Description

updated types definitions package so that the createdAtDate no longer requires a regex match to be accepted, this allows the createdAtDate to be saved as a full iso date string instead of just '2024-02-12' for example.

Related issue: [CB2-11103](https://dvsa.atlassian.net/browse/CB2-11103)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works