### PR TITLE
fix(cb2-10707): repair CT third mark validation

### DIFF
--- a/src/handler/updateVrm.ts
+++ b/src/handler/updateVrm.ts
@@ -11,12 +11,12 @@ import {
   updateVehicle,
 } from '../services/database';
 import { donorVehicle } from '../services/donorVehicle';
+import { publish } from '../services/sns';
 import { getUserDetails } from '../services/user';
+import { formatErrorMessage } from '../util/errorMessage';
 import { addHttpHeaders } from '../util/httpHeaders';
 import logger from '../util/logger';
 import { validateUpdateVrmRequest, validateVrm, validateVrmExists } from '../validators/update';
-import { formatErrorMessage } from '../util/errorMessage';
-import { publish } from '../services/sns';
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   try {
@@ -48,9 +48,10 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
       if (!thirdMark?.length) {
         const newVrmExistsOnActiveRecord = await validateVrmExists(newVrm);
-        if (newVrmExistsOnActiveRecord) {
-          return newVrmExistsOnActiveRecord;
-        }
+        if (newVrmExistsOnActiveRecord) return newVrmExistsOnActiveRecord;
+      } else {
+        const thirdMarkVrmExistsOnActiveRecord = await validateVrmExists(thirdMark);
+        if (thirdMarkVrmExistsOnActiveRecord) return thirdMarkVrmExistsOnActiveRecord;
       }
 
       const [donorVehicleRecord, error] = await donorVehicle(newVrm, thirdMark) as [TechRecordType<'get'>, APIGatewayProxyResult];


### PR DESCRIPTION
## Description

The CT backend wasn't making sure the third mark was not on an active record. It will now do this.

Related issue: [10707](https://dvsa.atlassian.net/browse/CB2-10707)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works