### PR TITLE
feat(CB2-14065): Update VTM seed data system numbers to unique identifiers

### DIFF
--- a/tests/resources/technical-records-v3.json
+++ b/tests/resources/technical-records-v3.json
@@ -15761,7 +15761,7 @@
     "vin": "VTAU1AUT0C9999998"
   },
   {
-    "systemNumber": "4000002",
+    "systemNumber": "6000002",
     "createdTimestamp": "2024-09-09T09:23:44.664Z",
     "partialVin": "000001",
     "primaryVrm": "AUTO01HGV",
@@ -15887,7 +15887,7 @@
     "vin": "AUT0MAT10N0000001"
   },
   {
-    "systemNumber": "4000003",
+    "systemNumber": "6000003",
     "createdTimestamp": "2024-09-09T09:23:44.664Z",
     "partialVin": "000001",
     "primaryVrm": "AUTO02HGV",
@@ -16013,7 +16013,7 @@
     "vin": "AUT0MAT10N0000002"
   },
   {
-    "systemNumber": "4000004",
+    "systemNumber": "6000004",
     "createdTimestamp": "2024-09-09T09:23:44.664Z",
     "partialVin": "000001",
     "primaryVrm": "AUTO03HGV",
@@ -16139,7 +16139,7 @@
     "vin": "AUT0MAT10N0000003"
   },
   {
-    "systemNumber": "4000005",
+    "systemNumber": "6000005",
     "createdTimestamp": "2024-09-09T09:23:44.664Z",
     "partialVin": "000001",
     "primaryVrm": "AUTO04HGV",
@@ -16265,7 +16265,7 @@
     "vin": "AUT0MAT10N0000004"
   },
   {
-    "systemNumber": "4000006",
+    "systemNumber": "6000006",
     "createdTimestamp": "2024-09-09T09:23:44.664Z",
     "partialVin": "000001",
     "primaryVrm": "AUTO05HGV",
@@ -16391,7 +16391,7 @@
     "vin": "AUT0MAT10N0000005"
   },
   {
-    "systemNumber": "4000007",
+    "systemNumber": "6000007",
     "createdTimestamp": "2024-09-09T09:23:44.664Z",
     "partialVin": "000001",
     "primaryVrm": "AUTO06HGV",
@@ -16517,7 +16517,7 @@
     "vin": "AUT0MAT10N0000006"
   },
   {
-    "systemNumber": "4000008",
+    "systemNumber": "6000008",
     "createdTimestamp": "2024-09-09T09:23:44.664Z",
     "partialVin": "000001",
     "primaryVrm": "AUTO07HGV",
@@ -16643,7 +16643,7 @@
     "vin": "AUT0MAT10N0000007"
   },
   {
-    "systemNumber": "4000009",
+    "systemNumber": "6000009",
     "createdTimestamp": "2024-09-09T09:23:44.664Z",
     "partialVin": "000001",
     "primaryVrm": "AUTO08HGV",
@@ -16769,7 +16769,7 @@
     "vin": "AUT0MAT10N0000008"
   },
   {
-    "systemNumber": "4000010",
+    "systemNumber": "6000010",
     "createdTimestamp": "2024-09-09T09:23:44.664Z",
     "partialVin": "000001",
     "primaryVrm": "AUTO09HGV",
@@ -16895,7 +16895,7 @@
     "vin": "AUT0MAT10N0000009"
   },
   {
-    "systemNumber": "4000011",
+    "systemNumber": "6000011",
     "createdTimestamp": "2024-09-09T09:23:44.664Z",
     "partialVin": "000001",
     "primaryVrm": "AUTO10HGV",
@@ -17021,7 +17021,7 @@
     "vin": "AUT0MAT10N0000010"
   },
   {
-    "systemNumber": "4000012",
+    "systemNumber": "6000012",
     "createdTimestamp": "2024-09-09T09:34:49.583Z",
     "partialVin": "000011",
     "primaryVrm": "AUTO01PSV",
@@ -17112,7 +17112,7 @@
     "vin": "AUT0MAT10N0000011"
   },
   {
-    "systemNumber": "4000013",
+    "systemNumber": "6000013",
     "createdTimestamp": "2024-09-09T09:34:49.583Z",
     "partialVin": "000011",
     "primaryVrm": "AUTO02PSV",
@@ -17203,7 +17203,7 @@
     "vin": "AUT0MAT10N0000012"
   },
   {
-    "systemNumber": "4000014",
+    "systemNumber": "6000014",
     "createdTimestamp": "2024-09-09T09:34:49.583Z",
     "partialVin": "000011",
     "primaryVrm": "AUTO03PSV",
@@ -17294,7 +17294,7 @@
     "vin": "AUT0MAT10N0000013"
   },
   {
-    "systemNumber": "4000015",
+    "systemNumber": "6000015",
     "createdTimestamp": "2024-09-09T09:34:49.583Z",
     "partialVin": "000011",
     "primaryVrm": "AUTO04PSV",
@@ -17385,7 +17385,7 @@
     "vin": "AUT0MAT10N0000014"
   },
   {
-    "systemNumber": "4000016",
+    "systemNumber": "6000016",
     "createdTimestamp": "2024-09-09T09:34:49.583Z",
     "partialVin": "000011",
     "primaryVrm": "AUTO05PSV",
@@ -17476,7 +17476,7 @@
     "vin": "AUT0MAT10N0000015"
   },
   {
-    "systemNumber": "4000017",
+    "systemNumber": "6000017",
     "createdTimestamp": "2024-09-09T09:34:49.583Z",
     "partialVin": "000011",
     "primaryVrm": "AUTO06PSV",
@@ -17567,7 +17567,7 @@
     "vin": "AUT0MAT10N0000016"
   },
   {
-    "systemNumber": "4000018",
+    "systemNumber": "6000018",
     "createdTimestamp": "2024-09-09T09:34:49.583Z",
     "partialVin": "000011",
     "primaryVrm": "AUTO07PSV",
@@ -17658,7 +17658,7 @@
     "vin": "AUT0MAT10N0000017"
   },
   {
-    "systemNumber": "4000019",
+    "systemNumber": "6000019",
     "createdTimestamp": "2024-09-09T09:34:49.583Z",
     "partialVin": "000011",
     "primaryVrm": "AUTO08PSV",
@@ -17749,7 +17749,7 @@
     "vin": "AUT0MAT10N0000018"
   },
   {
-    "systemNumber": "4000020",
+    "systemNumber": "6000020",
     "createdTimestamp": "2024-09-09T09:34:49.583Z",
     "partialVin": "000011",
     "primaryVrm": "AUTO09PSV",
@@ -17840,7 +17840,7 @@
     "vin": "AUT0MAT10N0000019"
   },
   {
-    "systemNumber": "4000021",
+    "systemNumber": "6000021",
     "createdTimestamp": "2024-09-09T09:34:49.583Z",
     "partialVin": "000011",
     "primaryVrm": "AUTO10PSV",
@@ -17931,7 +17931,7 @@
     "vin": "AUT0MAT10N0000020"
   },
   {
-    "systemNumber": "4400001",
+    "systemNumber": "6000022",
     "createdTimestamp": "2024-09-09T09:59:39.488Z",
     "partialVin": "000021",
     "techRecord_adrDetails_additionalExaminerNotes": null,
@@ -18064,7 +18064,7 @@
     "vin": "AUT0MAT10N0000021"
   },
   {
-    "systemNumber": "4400002",
+    "systemNumber": "6000023",
     "createdTimestamp": "2024-09-09T09:59:39.488Z",
     "partialVin": "000021",
     "techRecord_adrDetails_additionalExaminerNotes": null,
@@ -18197,7 +18197,7 @@
     "vin": "AUT0MAT10N0000022"
   },
   {
-    "systemNumber": "4400003",
+    "systemNumber": "6000024",
     "createdTimestamp": "2024-09-09T09:59:39.488Z",
     "partialVin": "000021",
     "techRecord_adrDetails_additionalExaminerNotes": null,
@@ -18330,7 +18330,7 @@
     "vin": "AUT0MAT10N0000023"
   },
   {
-    "systemNumber": "4400004",
+    "systemNumber": "6000025",
     "createdTimestamp": "2024-09-09T09:59:39.488Z",
     "partialVin": "000021",
     "techRecord_adrDetails_additionalExaminerNotes": null,
@@ -18463,7 +18463,7 @@
     "vin": "AUT0MAT10N0000024"
   },
   {
-    "systemNumber": "4400005",
+    "systemNumber": "6000026",
     "createdTimestamp": "2024-09-09T09:59:39.488Z",
     "partialVin": "000021",
     "techRecord_adrDetails_additionalExaminerNotes": null,
@@ -18596,7 +18596,7 @@
     "vin": "AUT0MAT10N0000025"
   },
   {
-    "systemNumber": "4400006",
+    "systemNumber": "6000027",
     "createdTimestamp": "2024-09-09T09:59:39.488Z",
     "partialVin": "000021",
     "techRecord_adrDetails_additionalExaminerNotes": null,
@@ -18729,7 +18729,7 @@
     "vin": "AUT0MAT10N0000026"
   },
   {
-    "systemNumber": "4400007",
+    "systemNumber": "6000028",
     "createdTimestamp": "2024-09-09T09:59:39.488Z",
     "partialVin": "000021",
     "techRecord_adrDetails_additionalExaminerNotes": null,
@@ -18862,7 +18862,7 @@
     "vin": "AUT0MAT10N0000027"
   },
   {
-    "systemNumber": "4400008",
+    "systemNumber": "6000029",
     "createdTimestamp": "2024-09-09T09:59:39.488Z",
     "partialVin": "000021",
     "techRecord_adrDetails_additionalExaminerNotes": null,
@@ -18995,7 +18995,7 @@
     "vin": "AUT0MAT10N0000028"
   },
   {
-    "systemNumber": "4400009",
+    "systemNumber": "6000030",
     "createdTimestamp": "2024-09-09T09:59:39.488Z",
     "partialVin": "000021",
     "techRecord_adrDetails_additionalExaminerNotes": null,
@@ -19128,7 +19128,7 @@
     "vin": "AUT0MAT10N0000029"
   },
   {
-    "systemNumber": "4400010",
+    "systemNumber": "6000031",
     "createdTimestamp": "2024-09-09T09:59:39.488Z",
     "partialVin": "000021",
     "techRecord_adrDetails_additionalExaminerNotes": null,


### PR DESCRIPTION
## Update VTM seed data system numbers to unique identifiers

This change is to amend the recently added seed data, system numbers so that it doesn't fall in the range of develop to prevent clashes with seed data and manually input data in develop.

Related issue: [CB2-14065](https://dvsa.atlassian.net/browse/CB2-14065)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works