### PR TITLE
feat(cb2-14236): update batch plate failure in handler for sync test result info

### DIFF
--- a/src/handler/sync-test-result-info.ts
+++ b/src/handler/sync-test-result-info.ts
@@ -35,7 +35,9 @@ export const handler = async (event: SQSEvent): Promise<SQSBatchResponse> => {
               test.euVehicleCategory as EUVehicleCategory || undefined,
             );
           } catch (error) {
-            logger.error(`an error occurred while processing test type for record ${record.messageId}: ${JSON.stringify(error)}`);
+            logger.error(`an error occurred while processing record ${record.messageId}: ${error instanceof Error
+              ? error.message
+              : JSON.stringify(error)}`);
             throw new Error('An error occurred while processing test type');
           }
         }

--- a/src/handler/sync-test-result-info.ts
+++ b/src/handler/sync-test-result-info.ts
@@ -1,7 +1,7 @@
 import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
-import { SQSBatchResponse, SQSEvent, SQSRecord } from 'aws-lambda';
+import { SQSBatchResponse, SQSEvent } from 'aws-lambda';
 import 'dotenv/config';
-import { TestResult, TestType } from '../models/testResult';
+import { TestResult } from '../models/testResult';
 import { processRecord } from '../processors/processSQSRecord';
 import { syncTestResultInfo } from '../processors/processSyncTestResultInfo';
 import logger from '../util/logger';
@@ -13,19 +13,19 @@ export const handler = async (event: SQSEvent): Promise<SQSBatchResponse> => {
     batchItemFailures: [],
   };
 
-  const promisesArray: Promise<object | undefined>[] = [];
-  try {
-    event.Records.forEach((record: SQSRecord) => {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const record of event.Records) {
+    try {
       logger.debug('payload received from queue:', record);
       const test = processRecord(record) as TestResult;
       logger.debug('processed record:', test ?? 'no test');
 
-      let promiseUpdateStatus: Promise<object | undefined> | undefined;
-
       if (test) {
-        test.testTypes.forEach((testType: TestType) => {
-          if (promiseUpdateStatus === undefined) {
-            promiseUpdateStatus = syncTestResultInfo(
+        // eslint-disable-next-line no-restricted-syntax
+        for (const testType of test.testTypes) {
+          try {
+            // eslint-disable-next-line no-await-in-loop
+            await syncTestResultInfo(
               test.systemNumber,
               test.testStatus,
               testType.testResult ?? '',
@@ -34,28 +34,17 @@ export const handler = async (event: SQSEvent): Promise<SQSBatchResponse> => {
               test.createdByName,
               test.euVehicleCategory as EUVehicleCategory || undefined,
             );
-            promisesArray.push(promiseUpdateStatus);
+          } catch (error) {
+            logger.error(`an error occurred while processing test type for record ${record.messageId}: ${JSON.stringify(error)}`);
+            throw new Error('An error occurred while processing test type');
           }
-        });
+        }
       }
-    });
-
-    const results = await Promise.allSettled(promisesArray);
-
-    results.forEach((r, i) => {
-      if (r.status === 'rejected' || !r.value) {
-        response.batchItemFailures.push({
-          // eslint-disable-next-line security/detect-object-injection
-          itemIdentifier: event.Records[i].messageId,
-        });
-      }
-    });
-
-    logger.info('resolved promises:', results);
-    return response;
-  } catch (error) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    logger.error(`an error occurred in the promises ${error}`);
-    throw error;
+    } catch (error) {
+      logger.error(`an error occurred while processing record ${record.messageId}: ${JSON.stringify(error)}`);
+      response.batchItemFailures.push({ itemIdentifier: record.messageId });
+    }
   }
+
+  return response;
 };

--- a/src/handler/sync-test-result-info.ts
+++ b/src/handler/sync-test-result-info.ts
@@ -23,27 +23,22 @@ export const handler = async (event: SQSEvent): Promise<SQSBatchResponse> => {
       if (test) {
         // eslint-disable-next-line no-restricted-syntax
         for (const testType of test.testTypes) {
-          try {
-            // eslint-disable-next-line no-await-in-loop
-            await syncTestResultInfo(
-              test.systemNumber,
-              test.testStatus,
-              testType.testResult ?? '',
-              testType.testTypeId,
-              test.createdById,
-              test.createdByName,
-              test.euVehicleCategory as EUVehicleCategory || undefined,
-            );
-          } catch (error) {
-            logger.error(`an error occurred while processing record ${record.messageId}: ${error instanceof Error
-              ? error.message
-              : JSON.stringify(error)}`);
-            throw new Error('An error occurred while processing test type');
-          }
+          // eslint-disable-next-line no-await-in-loop
+          await syncTestResultInfo(
+            test.systemNumber,
+            test.testStatus,
+            testType.testResult ?? '',
+            testType.testTypeId,
+            test.createdById,
+            test.createdByName,
+            test.euVehicleCategory as EUVehicleCategory || undefined,
+          );
         }
       }
     } catch (error) {
-      logger.error(`an error occurred while processing record ${record.messageId}: ${JSON.stringify(error)}`);
+      logger.error(`an error occurred while processing record ${record.messageId}: ${error instanceof Error
+        ? error.message
+        : JSON.stringify(error)}`);
       response.batchItemFailures.push({ itemIdentifier: record.messageId });
     }
   }

--- a/tests/unit/handler/sync-test-result-info.unit.test.ts
+++ b/tests/unit/handler/sync-test-result-info.unit.test.ts
@@ -4,6 +4,7 @@ const mockSyncTestResultInfo = jest.fn();
 import { handler } from '../../../src/handler/sync-test-result-info';
 import parsedRecord from '../../resources/queue-event-parsed-body.json';
 import queueEvent from '../../resources/queue-event.json';
+import logger from '../../../src/util/logger';
 
 jest.mock('../../../src/processors/processSQSRecord.ts', () => ({
   processRecord: mockProcessRecord,
@@ -25,6 +26,16 @@ describe('syncTestResultInfo handler', () => {
       expect(failures).toHaveLength(1);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       expect(failures[0]).toEqual({ itemIdentifier: queueEvent.Records[0].messageId });
+    });
+
+    it('should log and re-throw error in top-level catch block', async () => {
+      const error = new Error('some random error');
+      mockProcessRecord.mockImplementationOnce(() => { throw error; });
+
+      const loggerErrorSpy = jest.spyOn(logger, 'error');
+
+      await expect(handler(queueEvent)).rejects.toThrow(error);
+      expect(loggerErrorSpy).toHaveBeenCalledWith('an error occurred in the promises Error: some random error');
     });
   });
   describe('Success response', () => {

--- a/tests/unit/handler/sync-test-result-info.unit.test.ts
+++ b/tests/unit/handler/sync-test-result-info.unit.test.ts
@@ -4,7 +4,6 @@ const mockSyncTestResultInfo = jest.fn();
 import { handler } from '../../../src/handler/sync-test-result-info';
 import parsedRecord from '../../resources/queue-event-parsed-body.json';
 import queueEvent from '../../resources/queue-event.json';
-import logger from '../../../src/util/logger';
 
 jest.mock('../../../src/processors/processSQSRecord.ts', () => ({
   processRecord: mockProcessRecord,
@@ -19,23 +18,13 @@ describe('syncTestResultInfo handler', () => {
     jest.resetModules();
   });
   describe('Error handling', () => {
-    it('should now throw error if promise is rejected, but report on that failure', async () => {
+    it('should now throw error if problem with syncTestResulInfo method', async () => {
       mockProcessRecord.mockReturnValue(parsedRecord);
       mockSyncTestResultInfo.mockImplementation(() => Promise.reject(new Error('test error')));
       const failures = (await handler(queueEvent)).batchItemFailures;
       expect(failures).toHaveLength(1);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       expect(failures[0]).toEqual({ itemIdentifier: queueEvent.Records[0].messageId });
-    });
-
-    it('should log and re-throw error in top-level catch block', async () => {
-      const error = new Error('some random error');
-      mockProcessRecord.mockImplementationOnce(() => { throw error; });
-
-      const loggerErrorSpy = jest.spyOn(logger, 'error');
-
-      await expect(handler(queueEvent)).rejects.toThrow(error);
-      expect(loggerErrorSpy).toHaveBeenCalledWith('an error occurred in the promises Error: some random error');
     });
   });
   describe('Success response', () => {


### PR DESCRIPTION
The lambda in the title has a SQS snowball pattern within it. This needs to be refactored to be removed and stop the potential blocking of the lambda with batch failures

Related issue: [CB2-14236](https://dvsa.atlassian.net/browse/CB2-14236)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works