### PR TITLE
fix(cb2-16022): Allow ADR Body Declaration to be saved as null when Explosives Type 3 is not selected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dvsa/aws-utilities": "^1.2.0",
         "@dvsa/cvs-feature-flags": "^0.18.0",
         "@dvsa/cvs-microservice-common": "^1.2.4",
-        "@dvsa/cvs-type-definitions": "^7.9.1",
+        "@dvsa/cvs-type-definitions": "^7.10.0",
         "@types/luxon": "^3.3.0",
         "jwt-decode": "^3.1.2",
         "luxon": "^3.3.0",
@@ -7154,10 +7154,9 @@
       }
     },
     "node_modules/@dvsa/cvs-type-definitions": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-7.9.1.tgz",
-      "integrity": "sha512-uvuxf25vsIjXcL18mihtKlnyriilF6vvhJapSw0PNnArYwryjP4+9FGykp3qDbHbGEJgrcwLoPQRrvut7CKzuw==",
-      "license": "ISC",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-7.10.0.tgz",
+      "integrity": "sha512-AnpbxPMTgvc7mOqzHmDg3gR51SzNX2EbYeX25e+uui+vvY2geRuF0KAEP/ZyLZruWD5OMJ+DnMPUqfyAJV/x0Q==",
       "dependencies": {
         "ajv": "^8.12.0",
         "json-schema-deref-sync": "^0.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dvsa/aws-utilities": "^1.2.0",
         "@dvsa/cvs-feature-flags": "^0.18.0",
         "@dvsa/cvs-microservice-common": "^1.2.4",
-        "@dvsa/cvs-type-definitions": "^7.8.0",
+        "@dvsa/cvs-type-definitions": "^7.9.1",
         "@types/luxon": "^3.3.0",
         "jwt-decode": "^3.1.2",
         "luxon": "^3.3.0",
@@ -7154,9 +7154,9 @@
       }
     },
     "node_modules/@dvsa/cvs-type-definitions": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-7.8.0.tgz",
-      "integrity": "sha512-yGuAm6ZeoOjy+3Q+ftsbTyP5fdUYn8RJEP/DSWIhmkY7r+xjJ7eKG9zuNXRJWIyrgfprtiu1Vq91cy6IuDSBcg==",
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-7.9.1.tgz",
+      "integrity": "sha512-uvuxf25vsIjXcL18mihtKlnyriilF6vvhJapSw0PNnArYwryjP4+9FGykp3qDbHbGEJgrcwLoPQRrvut7CKzuw==",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dvsa/aws-utilities": "^1.2.0",
     "@dvsa/cvs-feature-flags": "^0.18.0",
     "@dvsa/cvs-microservice-common": "^1.2.4",
-    "@dvsa/cvs-type-definitions": "^7.9.1",
+    "@dvsa/cvs-type-definitions": "^7.10.0",
     "@types/luxon": "^3.3.0",
     "jwt-decode": "^3.1.2",
     "luxon": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dvsa/aws-utilities": "^1.2.0",
     "@dvsa/cvs-feature-flags": "^0.18.0",
     "@dvsa/cvs-microservice-common": "^1.2.4",
-    "@dvsa/cvs-type-definitions": "^7.8.0",
+    "@dvsa/cvs-type-definitions": "^7.9.1",
     "@types/luxon": "^3.3.0",
     "jwt-decode": "^3.1.2",
     "luxon": "^3.3.0",

--- a/tests/unit/handler/update.unit.test.ts
+++ b/tests/unit/handler/update.unit.test.ts
@@ -11,6 +11,7 @@ import { ERRORS } from '../../../src/util/enum';
 import { formatErrorMessage } from '../../../src/util/errorMessage';
 import hgvData from '../../resources/techRecordHGVPost.json';
 import { mockToken } from '../util/mockToken';
+import { EUVehicleCategory } from "@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategoryTrl.enum.js";
 
 const trlPayload = {
   techRecord_reasonForCreation: 'Test Update',
@@ -23,6 +24,7 @@ const trlPayload = {
   trailerId: 'C530005',
   techRecord_bodyType_description: 'artic',
   techRecord_bodyType_code: 'a',
+  techRecord_euVehicleCategory: EUVehicleCategory.O3
 };
 
 jest.mock('../../../src/services/database.ts', () => ({

--- a/tests/unit/handler/update.unit.test.ts
+++ b/tests/unit/handler/update.unit.test.ts
@@ -5,13 +5,13 @@ const mockProcessUpdateRequest = jest.fn();
 
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
 import { APIGatewayProxyEvent } from 'aws-lambda';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategoryTrl.enum.js';
 import { handler } from '../../../src/handler/update';
 import * as UserDetails from '../../../src/services/user';
 import { ERRORS } from '../../../src/util/enum';
 import { formatErrorMessage } from '../../../src/util/errorMessage';
 import hgvData from '../../resources/techRecordHGVPost.json';
 import { mockToken } from '../util/mockToken';
-import { EUVehicleCategory } from "@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategoryTrl.enum.js";
 
 const trlPayload = {
   techRecord_reasonForCreation: 'Test Update',
@@ -24,7 +24,7 @@ const trlPayload = {
   trailerId: 'C530005',
   techRecord_bodyType_description: 'artic',
   techRecord_bodyType_code: 'a',
-  techRecord_euVehicleCategory: EUVehicleCategory.O3
+  techRecord_euVehicleCategory: EUVehicleCategory.O3,
 };
 
 jest.mock('../../../src/services/database.ts', () => ({


### PR DESCRIPTION
## Allow ADR Body Declaration to be saved as null when Explosives Type 3 is not selected

Bumps to latest type definitions package.

Related issue: [16022](https://dvsa.atlassian.net/browse/CB2-16022)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works