### PR TITLE
feat(CB2-21417): fix transaction error in sync test result

### DIFF
--- a/src/processors/processSyncTestResultInfo.ts
+++ b/src/processors/processSyncTestResultInfo.ts
@@ -100,18 +100,25 @@ export const syncTestResultInfo = async (
   if (updateNeeded) {
     const updatedNewRecords: TechRecordType<'get'>[] = [];
     const updatedRecordsToArchive: TechRecordType<'get'>[] = [];
-    newRecords.forEach((record) => {
+
+    const now = new Date();
+
+    newRecords.forEach((record, index) => {
+      // add the `index` to the time to make each record unique
+      const timestamp = new Date(now.getTime() + index).toISOString();
+
       updatedNewRecords.push(setCreatedAuditDetails(
         record as TechRecordType<'get'>,
         createdByName,
         createdById,
-        new Date().toISOString(),
+        timestamp,
         record.techRecord_statusCode as StatusCode,
       ));
     });
+
     recordsToArchive.forEach((record) => {
       record.techRecord_updateType = UpdateType.TECH_RECORD_UPDATE;
-      updatedRecordsToArchive.push(setLastUpdatedAuditDetails(record, createdByName, createdById, new Date().toISOString(), StatusCode.ARCHIVED));
+      updatedRecordsToArchive.push(setLastUpdatedAuditDetails(record, createdByName, createdById, now.toISOString(), StatusCode.ARCHIVED));
     });
 
     return updateVehicle(

--- a/tests/unit/processors/processSyncTestResultInfo.unit.test.ts
+++ b/tests/unit/processors/processSyncTestResultInfo.unit.test.ts
@@ -78,8 +78,10 @@ describe('syncTestResultInfo', () => {
       mockUpdateVehicle.mockResolvedValueOnce({});
       await syncTestResultInfo('5000', 'submitted', 'pass', '10', '012345', 'Test User', EUVehicleCategory.M2);
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const [, newRecords] = mockUpdateVehicle.mock.calls[0];
       expect(newRecords).toHaveLength(2);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(newRecords[0].createdTimestamp).not.toEqual(newRecords[1].createdTimestamp);
     });
     it('should not call update if record is current and EuVehicleCategory is not updated', async () => {

--- a/tests/unit/processors/processSyncTestResultInfo.unit.test.ts
+++ b/tests/unit/processors/processSyncTestResultInfo.unit.test.ts
@@ -71,6 +71,17 @@ describe('syncTestResultInfo', () => {
       expect(mockGetBySystemNumberAndCreatedTimestamp).toHaveBeenCalledTimes(2);
       expect(mockUpdateVehicle).toHaveBeenCalledTimes(1);
     });
+    it('should use unique createdTimestamps when creating multiple new records', async () => {
+      mockSearchByCriteria.mockResolvedValueOnce([{ techRecord_statusCode: 'current' }, { techRecord_statusCode: 'provisional' }]);
+      mockGetBySystemNumberAndCreatedTimestamp.mockResolvedValueOnce(hgvData[1]);
+      mockGetBySystemNumberAndCreatedTimestamp.mockResolvedValueOnce(hgvData[0]);
+      mockUpdateVehicle.mockResolvedValueOnce({});
+      await syncTestResultInfo('5000', 'submitted', 'pass', '10', '012345', 'Test User', EUVehicleCategory.M2);
+
+      const [, newRecords] = mockUpdateVehicle.mock.calls[0];
+      expect(newRecords).toHaveLength(2);
+      expect(newRecords[0].createdTimestamp).not.toEqual(newRecords[1].createdTimestamp);
+    });
     it('should not call update if record is current and EuVehicleCategory is not updated', async () => {
       mockSearchByCriteria.mockResolvedValueOnce([{ techRecord_statusCode: 'current' }]);
       mockGetBySystemNumberAndCreatedTimestamp.mockResolvedValueOnce(hgvData[1]);


### PR DESCRIPTION
## Description

- Make the timstamp unique by adding a unique index value to each in the loop

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works